### PR TITLE
bundle lock --add-platform x86_64-linux after remove gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -165,6 +165,8 @@ GEM
     nio4r (2.5.9)
     nokogiri (1.15.2-x86_64-darwin)
       racc (~> 1.4)
+    nokogiri (1.15.2-x86_64-linux)
+      racc (~> 1.4)
     orm_adapter (0.5.0)
     pg (1.5.3)
     pg_search (2.3.6)
@@ -272,6 +274,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-20
+  x86_64-linux
 
 DEPENDENCIES
   autoprefixer-rails


### PR DESCRIPTION
J'ai rajouté x86_64-linux dans le gemfile.lock suite à la suppression du gemfile.lock puis d'un bundle. Cette dernière ne s'était pas remis